### PR TITLE
fix: OnlyUpperBodyが有効な場合はhipsの回転を禁止

### DIFF
--- a/VMagicMirror_MotionExporter/Assets/Baku/VMagicMirror_MotionExporter/Scripts/TestPlay/MotionTestPlay.cs
+++ b/VMagicMirror_MotionExporter/Assets/Baku/VMagicMirror_MotionExporter/Scripts/TestPlay/MotionTestPlay.cs
@@ -62,7 +62,11 @@ namespace Baku.VMagicMirror.MotionExporter
 
             //何も対策しないとhipsが徐々にずれることが多いので、それを防ぐ
             _hips.localPosition = _originHipPos;
-            //_hips.localRotation = _originHipRot;
+            if (!onlyUpperBody)
+            {
+                //上半身のみ動作の場合、hipsの回転があると下半身が丸ごと動いてしまうため、それは禁止する
+                _hips.localRotation = _originHipRot;
+            }
         }
     }
 }


### PR DESCRIPTION
VMagicMirror向けのルックの確認に支障が出るため、追加で修正しました。