### PR TITLE
replace invalid filename char in target clip name

### DIFF
--- a/VMagicMirror_MotionExporter/Assets/Baku/VMagicMirror_MotionExporter/Scripts/Editor/MotionExporterEditor.cs
+++ b/VMagicMirror_MotionExporter/Assets/Baku/VMagicMirror_MotionExporter/Scripts/Editor/MotionExporterEditor.cs
@@ -38,6 +38,12 @@ namespace Baku.VMagicMirror.MotionExporter
                 return;
             }
 
+            char[] invalidChars = Path.GetInvalidFileNameChars();
+            foreach (var invalidChar in invalidChars)
+            {
+                clipName = clipName.Replace(invalidChar, '_');
+            }
+
             string json = JsonUtility.ToJson(motion);
             var filePath = Path.Combine(
                 Application.streamingAssetsPath,


### PR DESCRIPTION
fixed #5 

- Replace invalid file name char (including '|', referred in the issue) to underscore ('_'), when exporting

This fix has no effect for import operation. 