### PR TITLE
v1.0.2

### DIFF
--- a/VMagicMirror_MotionExporter/Assets/Baku/VMagicMirror_MotionExporter/Scripts/Editor/MotionExporterEditor.cs
+++ b/VMagicMirror_MotionExporter/Assets/Baku/VMagicMirror_MotionExporter/Scripts/Editor/MotionExporterEditor.cs
@@ -38,6 +38,12 @@ namespace Baku.VMagicMirror.MotionExporter
                 return;
             }
 
+            char[] invalidChars = Path.GetInvalidFileNameChars();
+            foreach (var invalidChar in invalidChars)
+            {
+                clipName = clipName.Replace(invalidChar, '_');
+            }
+
             string json = JsonUtility.ToJson(motion);
             var filePath = Path.Combine(
                 Application.streamingAssetsPath,

--- a/VMagicMirror_MotionExporter/Assets/Baku/VMagicMirror_MotionExporter/Scripts/TestPlay/MotionTestPlay.cs
+++ b/VMagicMirror_MotionExporter/Assets/Baku/VMagicMirror_MotionExporter/Scripts/TestPlay/MotionTestPlay.cs
@@ -62,7 +62,7 @@ namespace Baku.VMagicMirror.MotionExporter
 
             //何も対策しないとhipsが徐々にずれることが多いので、それを防ぐ
             _hips.localPosition = _originHipPos;
-            if (!onlyUpperBody)
+            if (onlyUpperBody)
             {
                 //上半身のみ動作の場合、hipsの回転があると下半身が丸ごと動いてしまうため、それは禁止する
                 _hips.localRotation = _originHipRot;


### PR DESCRIPTION
#6 #7 のfixを反映します。

- アニメーションクリップにファイル名で使えない文字(`|`など)が含まれる時、エクスポートに失敗する問題を修正しました。
- テストプレイ時、`Only Upper Body`がオンになっていても下半身が動いてしまう場合がある問題を修正しました。

この変更はいずれもMotionExporterの内部的な修正で、モーションのエクスポート/検証時のユーザビリティを改善します。VMagicMirror本体には特に影響しません。
